### PR TITLE
Update wording for bound and free variables

### DIFF
--- a/Vorlesungen/lecture-13.tex
+++ b/Vorlesungen/lecture-13.tex
@@ -375,8 +375,7 @@ bezeichnen, was zu unterschiedlichen Teilformeln führt.}
 
 \begin{frame}\frametitle{Freie und gebundene Variablenvorkommen}
 
-Eine Variable kann in einer Formel entweder \alert{frei} oder \alert{gebunden}
-vorkommen:
+Jedes Vorkommen einer Variable in einer Formel ist entweder \alert{frei} oder \alert{gebunden}:
 
 \defbox{Die \redalert{freien Vorkommen} von Variablen in einer Formel sind rekursiv wie folgt definiert:
 \begin{itemize}


### PR DESCRIPTION
#### Motivation

In my opinion the following sentence could cause confusion:
> Eine Variable kann in einer Formel entweder \alert{frei} oder \alert{gebunden} vorkommen

which could be interpreted as

> Eine Variable kann in einer Formel entweder \alert{frei} oder \alert{gebunden} vorkommen **(aber nicht beides)**

which is wrong.

See https://youtu.be/khzeIeGtwfI?t=1438

#### Proposed change

Therefore I propose to change that to:

> Jedes Vorkommen einer Variable in einer Formel ist entweder \alert{frei} oder \alert{gebunden}:

This would be 6 letters longer and would fit well into the slide:

Before:

![before](https://user-images.githubusercontent.com/85715453/121616584-ab991f00-ca52-11eb-949e-0ce5b705e228.png)

After:

![after](https://user-images.githubusercontent.com/85715453/121615462-74c20980-ca50-11eb-8f46-7eb34db98d3a.png)

I have tested the LaTeX build. It compiles correctly and the slide looks correct (see screenshot).

#### License: CC0

<a rel="license"
     href="http://creativecommons.org/publicdomain/zero/1.0/">
    <img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" />
  </a>

To the extent possible under law, f5a3a0726ef85b95 has waived all copyright and related or neighboring rights to "Update wording for bound and free variables". This work is published from: Germany.